### PR TITLE
style updates & prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,9 +1,21 @@
 {
-	"useTabs": false,
-	"singleQuote": true,
-	"trailingComma": "none",
-	"printWidth": 80,
-	"plugins": ["prettier-plugin-svelte"],
-	"pluginSearchDirs": ["."],
-	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
+    "useTabs": false,
+    "singleQuote": true,
+    "trailingComma": "none",
+    "printWidth": 80,
+    "plugins": [
+        "prettier-plugin-svelte"
+    ],
+    "pluginSearchDirs": [
+        "."
+    ],
+    "overrides": [
+        {
+            "files": "*.svelte",
+            "options": {
+                "parser": "svelte"
+            }
+        }
+    ],
+    "bracketSameLine": true
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,16 +4,19 @@
     "trailingComma": "none",
     "printWidth": 80,
     "plugins": [
-        "prettier-plugin-svelte"
+        "./node_modules/prettier-plugin-svelte",
+        "./node_modules/prettier-plugin-tailwindcss"
     ],
-    "pluginSearchDirs": [
-        "."
-    ],
+    "pluginSearchDirs": false,
     "overrides": [
         {
             "files": "*.svelte",
             "options": {
-                "parser": "svelte"
+                "parser": "svelte",
+                "svelteSortOrder": "scripts-markup-styles",
+                "svelteBracketNewLine": false,
+                "svelteAllowShorthand": true,
+                "svelteIndentScriptAndStyle": true
             }
         }
     ],

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"postcss": "^8.4.21",
 		"prettier": "^2.8.0",
 		"prettier-plugin-svelte": "^2.8.1",
+		"prettier-plugin-tailwindcss": "^0.2.6",
 		"rehype-add-classes": "^1.0.0",
 		"rehype-external-links": "^2.0.1",
 		"rehype-slug": "^5.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ devDependencies:
   prettier-plugin-svelte:
     specifier: ^2.8.1
     version: 2.10.0(prettier@2.8.7)(svelte@3.57.0)
+  prettier-plugin-tailwindcss:
+    specifier: ^0.2.6
+    version: 0.2.6(prettier-plugin-svelte@2.10.0)(prettier@2.8.7)
   rehype-add-classes:
     specifier: ^1.0.0
     version: 1.0.0
@@ -1778,6 +1781,62 @@ packages:
     dependencies:
       prettier: 2.8.7
       svelte: 3.57.0
+    dev: true
+
+  /prettier-plugin-tailwindcss@0.2.6(prettier-plugin-svelte@2.10.0)(prettier@2.8.7):
+    resolution: {integrity: sha512-F+7XCl9RLF/LPrGdUMHWpsT6TM31JraonAUyE6eBmpqymFvDwyl0ETHsKFHP1NG+sEfv8bmKqnTxEbWQbHPlBA==}
+    engines: {node: '>=12.17.0'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-php': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@shufo/prettier-plugin-blade': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      prettier: '>=2.2.0'
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-import-sort: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-style-order: '*'
+      prettier-plugin-svelte: '*'
+      prettier-plugin-twig-melody: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-php':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@shufo/prettier-plugin-blade':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-import-sort:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-style-order:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
+      prettier-plugin-twig-melody:
+        optional: true
+    dependencies:
+      prettier: 2.8.7
+      prettier-plugin-svelte: 2.10.0(prettier@2.8.7)(svelte@3.57.0)
     dev: true
 
   /prettier@2.8.7:

--- a/src/app.postcss
+++ b/src/app.postcss
@@ -32,12 +32,6 @@ h5 {
   }
 }
 
-code:not(.unstyled):is(:not(pre *)) {
-  @apply whitespace-nowrap font-mono text-xs text-primary-700 dark:text-primary-400;
-  @apply bg-primary-500/30 dark:bg-primary-500/20;
-  @apply rounded py-0.5 px-1;
-}
-
 .md-list {
   a,
   code {

--- a/src/app.postcss
+++ b/src/app.postcss
@@ -11,7 +11,6 @@ h3,
 h4,
 h5 {
   display: flex;
-  font-family: 'Inter', sans-serif !important;
   a {
     margin-left: 4px;
     font-size: 1.3rem;
@@ -34,9 +33,9 @@ h5 {
 }
 
 code:not(.unstyled):is(:not(pre *)) {
-  @apply font-mono text-xs text-primary-700 dark:text-primary-400 whitespace-nowrap;
+  @apply whitespace-nowrap font-mono text-xs text-primary-700 dark:text-primary-400;
   @apply bg-primary-500/30 dark:bg-primary-500/20;
-  @apply py-0.5 px-1 rounded;
+  @apply rounded py-0.5 px-1;
 }
 
 .md-list {

--- a/src/lib/mdsvex/MarkdownLayout.svelte
+++ b/src/lib/mdsvex/MarkdownLayout.svelte
@@ -9,7 +9,6 @@
 </script>
 
 <div
-  class="p-6 md:p-10 {fullWidth ? '' : 'max-w-4xl'} mx-auto prose prose-invert"
->
+  class="{fullWidth ? '' : 'max-w-4xl'} prose prose-invert mx-auto p-6 md:p-10">
   <slot />
 </div>

--- a/src/lib/navigation/A.svelte
+++ b/src/lib/navigation/A.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
-	import { page } from '$app/stores';
+  import { page } from '$app/stores';
 
-	export let href: string;
-	$: current = $page.url.pathname == href;
+  export let href: string;
+  $: current = $page.url.pathname == href;
 </script>
 
-<a class:bg-primary-active-token={current} {href} {...$$props}><slot /></a>
+<a
+  class:bg-primary-active-token={current}
+  class="font-medium"
+  {href}
+  {...$$props}>
+  <slot />
+</a>

--- a/src/theme.postcss
+++ b/src/theme.postcss
@@ -14,7 +14,7 @@
   --theme-rounded-container: 8px;
   --theme-border-base: 1px;
   /* =~= Theme On-X Colors =~= */
-  --on-primary: 255 255 255;
+  --on-primary: 21 23 31;
   --on-secondary: 255 255 255;
   --on-tertiary: 0 0 0;
   --on-success: 0 0 0;

--- a/src/theme.postcss
+++ b/src/theme.postcss
@@ -7,7 +7,10 @@
     BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans',
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
     'Noto Color Emoji';
-  --theme-font-family-heading: system-ui;
+  --theme-font-family-heading: Inter, ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans',
+    sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+    'Noto Color Emoji';
   --theme-font-color-base: var(--color-surface-900);
   --theme-font-color-dark: var(--color-surface-50);
   --theme-rounded-base: 24px;

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -23,7 +23,7 @@ module.exports = {
       fontFamily: {
         sans: ['Inter', 'sans-serif']
       },
-      typography: {
+      typography: (them) => ({
         DEFAULT: {
           css: {
             p: {
@@ -35,6 +35,18 @@ module.exports = {
             },
             'code::after': {
               content: 'none'
+            },
+            'code:is(:not(pre *))': {
+              fontFamily:
+                'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+              fontSize: '0.875rem',
+              lineHeight: '1.25rem',
+              whiteSpace: 'nowrap',
+              backgroundColor: 'rgb(var(--color-primary-500) / 0.2)',
+              color: 'rgb(var(--color-primary-400) / 1)',
+              opacity: '1',
+              borderRadius: '0.25rem',
+              padding: '0.125rem 0.25rem'
             },
             ul: {
               listStyle: 'none'
@@ -85,7 +97,7 @@ module.exports = {
             }
           }
         }
-      }
+      })
     }
   },
   plugins: [

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -68,6 +68,9 @@ module.exports = {
             h3: {
               marginTop: '1.75rem'
             },
+            h4: {
+              fontSize: '1.125rem'
+            },
             'a:is(.card)': {
               textDecoration: 'none'
             },
@@ -80,6 +83,9 @@ module.exports = {
             },
             'div pre': {
               marginBottom: '1.25rem!important'
+            },
+            table: {
+              marginTop: 0
             },
             'table td': {
               padding: '1rem!important',

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -63,7 +63,7 @@ module.exports = {
             },
             h2: {
               marginTop: '2.5rem',
-              marginBottom: '1.25rem'
+              marginBottom: '1rem'
             },
             h3: {
               marginTop: '1.75rem'


### PR DESCRIPTION
- Updated the them `on-primary` color to the darkest surface color to fix issues with contract.
- Added the prettier tailwind plugin which autosorts tailwind classes in a predictible fashion (dev dependency)
- Moved some code from the `app.postcss` file into the tailwind prose configuration so the styles don't impact parts of the site beyond the rendered markdown in the future