### PR TITLE
Tailwind v3.3 doesn't need the line-clamp plugin anymore.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@sveltejs/adapter-vercel": "^2.4.3",
     "@sveltejs/kit": "^1.15.9",
     "@tailwindcss/forms": "^0.5.3",
-    "@tailwindcss/line-clamp": "^0.4.4",
     "@tailwindcss/typography": "^0.5.9",
     "@types/canvas-confetti": "^1.6.0",
     "@types/marked": "^4.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,9 +25,6 @@ devDependencies:
   '@tailwindcss/forms':
     specifier: ^0.5.3
     version: 0.5.3(tailwindcss@3.3.2)
-  '@tailwindcss/line-clamp':
-    specifier: ^0.4.4
-    version: 0.4.4(tailwindcss@3.3.2)
   '@tailwindcss/typography':
     specifier: ^0.5.9
     version: 0.5.9(tailwindcss@3.3.2)
@@ -588,14 +585,6 @@ packages:
       tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1'
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.3.2
-    dev: true
-
-  /@tailwindcss/line-clamp@0.4.4(tailwindcss@3.3.2):
-    resolution: {integrity: sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==}
-    peerDependencies:
-      tailwindcss: '>=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1'
-    dependencies:
       tailwindcss: 3.3.2
     dev: true
 

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -113,7 +113,6 @@ module.exports = {
   plugins: [
     require('@tailwindcss/forms'),
     require('@tailwindcss/typography'),
-    require('@tailwindcss/line-clamp'),
     ...require('@skeletonlabs/skeleton/tailwind/skeleton.cjs')()
   ]
 };


### PR DESCRIPTION
-removes line-clamp plugin from deps and tailwind.config.cjs 


---
warn - As of Tailwind CSS v3.3, the `@tailwindcss/line-clamp` plugin is now included by default. 
warn - Remove it from the `plugins` array in your configuration to eliminate this warning.