### PR TITLE
remove use of Array.prototype.at

### DIFF
--- a/src/routes/DocsSearch.svelte
+++ b/src/routes/DocsSearch.svelte
@@ -86,7 +86,7 @@
 
     function focusOn(index: number) {
       e.preventDefault();
-      list.at(index)?.focus();
+      list?.[index]?.focus();
     }
 
     if (current === 0 && list.length > 1) {

--- a/src/routes/DocsSearch.svelte
+++ b/src/routes/DocsSearch.svelte
@@ -97,7 +97,7 @@
       }
     } else if (e.code === 'ArrowUp' && e.target === list[1]) {
       focusOn(0);
-    } else if (e.code === 'ArrowDown' && e.target === list.at(-1)) {
+    } else if (e.code === 'ArrowDown' && e.target === list[list.length - 1]) {
       focusOn(0);
     } else if (e.code == 'Backspace') {
       list[0].focus();


### PR DESCRIPTION
Replaces the usage of the Array.prototype.at method with the array[] syntax for cross-browser compatibility with older iOS Safari versions.