### PR TITLE
Update throwing server errors

### DIFF
--- a/src/routes/concepts/error-handling/+page.md
+++ b/src/routes/concepts/error-handling/+page.md
@@ -70,7 +70,7 @@ setError(form, `post.tags[${i}].name`, 'Invalid tag name.');
 
 ## Throwing server errors
 
-If something goes wrong beyond validation, instead of `return fail(400, { form })`, you can also `throw error(5xx)`, which can then be handled with the [onError](/concepts/events#onerror) event, or, if the custom [use:enhance](/concepts/enhance) doesn't exist on the form, the nearest +error.svelte page will be rendered.
+If something goes wrong beyond validation, instead of `return fail(400, { form })`, you can also call the [error(...)](https://kit.svelte.dev/docs/errors#expected-errors) helper from SvelteKit or `throw error(5xx)`, which can then be caught with the [onError](/concepts/events#onerror) event, or, if the custom [use:enhance](/concepts/enhance) doesn't exist on the form, the nearest +error.svelte page will be rendered.
 
 To avoid data loss even for non-javascript users, returning a [status message](/concepts/messages) instead of throwing an error is recommended.
 


### PR DESCRIPTION
Hey there! 👋 This PR updates an alternative method in SvelteKit for throwing server errors. In the past (sveltekit v1), you had to [explicitly throw an error](https://kit.svelte.dev/docs/migrating-to-sveltekit-2#redirect-and-error-are-no-longer-thrown-by-you), but with v2, simply need to call the [error(...)](https://kit.svelte.dev/docs/errors#expected-errors) helper function. 
