### PR TITLE
Update +page.md to fix typo

### DIFF
--- a/src/routes/get-started/[...lib]/+page.md
+++ b/src/routes/get-started/[...lib]/+page.md
@@ -78,7 +78,7 @@ const schema = type({
 ```ts
 import Joi from 'joi';
 
-const schema = z.object({
+const schema = Joi.object({
   name: Joi.string().default('Hello world!'),
   email: Joi.string().email().required()
 });
@@ -172,7 +172,7 @@ import { joi } from 'sveltekit-superforms/adapters';
 import Joi from 'joi';
 
 // Define outside the load function so the adapter can be cached
-const schema = z.object({
+const schema = Joi.object({
   name: Joi.string().default('Hello world!'),
   email: Joi.string().email().required()
 });


### PR DESCRIPTION
When Joi was selected for validation, some references to z were left in the sample schemas. if used they would cause a reference error as z is not available.