### PR TITLE
Fix TS generics in FAQ reuse common options

### DIFF
--- a/src/routes/faq/+page.md
+++ b/src/routes/faq/+page.md
@@ -233,10 +233,12 @@ export type Message = {
 };
 
 // If no strongly type message is needed, leave out the M type parameter
-export function mySuperForm<T extends Record<string, unknown>, M = Message>(
-  ...params: Parameters<typeof superForm<T, M>>
-) {
-  return superForm<T, M>(params[0], {
+export function mySuperForm<
+  T extends Record<string, unknown>,
+  M = Message,
+  In extends Record<string, unknown> = T
+>(...params: Parameters<typeof superForm<T, M, In>>) {
+  return superForm<T, M, In>(params[0], {
     // Your defaults here
     errorSelector: '.has-error',
     delayMs: 300,


### PR DESCRIPTION
When using the custom superForm wrapper function without passing the 3rd Generic, the TS type of `form.data` in `onUpdate` event handler is inferred to be "Partial" (fields with default values are optional).
I tried adding this 3rd generic, and it fixed the type issue.