### PR TITLE
Fix broken github url

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -263,8 +263,8 @@
         Found a typo or an inconsistency? Make a quick correction <a
           target="_blank"
           class="underline"
-          href="https://github.com/ciscoheat/superforms-web/tree/main/src/routes{$page.url
-            .pathname}/+page.md">here</a
+          href="https://github.com/ciscoheat/superforms-web/tree/main/src/routes{$page.route
+            .id}/+page.md">here</a
         >!
       </div>
     {/if}


### PR DESCRIPTION
> Found a typo or an inconsistency? Make a quick correction here!
> https://superforms.rocks/get-started

The above page has a slug that's not accounted for.