### PR TITLE
English wording fix: eventual -> potential

### DIFF
--- a/src/routes/faq/+page.md
+++ b/src/routes/faq/+page.md
@@ -22,7 +22,7 @@ Use the `resetForm: false` option for `superForm`, as described on the [use:enha
 
 The object returned from `superValidate`, called [SuperValidated](/api#supervalidate-return-type), is used to instantiate a `superForm`, just like a required argument in a constructor. 
 
-It contains [constraints](/concepts/client-validation#built-in-browser-validation), [form id](/concepts/multiple-forms) based on the schema, an internal structure for handling errors in [nested data](/concepts/nested-data), eventual [initial errors](/concepts/error-handling#initial-form-errors), and more.
+It contains [constraints](/concepts/client-validation#built-in-browser-validation), [form id](/concepts/multiple-forms) based on the schema, an internal structure for handling errors in [nested data](/concepts/nested-data), potential [initial errors](/concepts/error-handling#initial-form-errors), and more.
 
 In special cases you can send an object with just the form data to `superForm`, but that is only for:
 

--- a/src/routes/get-started/[...lib]/+page.md
+++ b/src/routes/get-started/[...lib]/+page.md
@@ -215,7 +215,7 @@ const schema = z.object({
 
 #### Schema caching
 
-The schema should be defined outside the load function, in this case on the top level of the module. **This is very important to make caching work.** The adapter is memoized (cached) with its arguments, so they must be kept in memory. Therefore, define the schema, its options and eventual defaults on the top level of a module, so they always refer to the same object.
+The schema should be defined outside the load function, in this case on the top level of the module. **This is very important to make caching work.** The adapter is memoized (cached) with its arguments, so they must be kept in memory. Therefore, define the schema, its options and potential defaults on the top level of a module, so they always refer to the same object.
 
 ### Initializing the form in the load function
 

--- a/src/routes/migration-v2/+page.md
+++ b/src/routes/migration-v2/+page.md
@@ -85,7 +85,7 @@ export const load = async () => {
 
 #### Schema caching
 
-In the example above, both the schema and the defaults are defined outside the load function, on the top level of the module. **This is very important to make caching work.** The adapter is memoized (cached) with its arguments, so they must be kept in memory. Therefore, define the schema, options and eventual default values for the adapter on the top level of a module, so they always refer to the same object.
+In the example above, both the schema and the defaults are defined outside the load function, on the top level of the module. **This is very important to make caching work.** The adapter is memoized (cached) with its arguments, so they must be kept in memory. Therefore, define the schema, options and potential default values for the adapter on the top level of a module, so they always refer to the same object.
 
 #### Optimized client-side validation
 
@@ -162,7 +162,7 @@ The quite popular `superValidateSync` function has changed, since it's not possi
 
 Since this is a bit of a security issue, `superValidateSync` has been renamed to `defaults`.
 
-Fortunately though, a [quick Github search](https://github.com/search?q=superValidateSync%28&type=code) reveals that most of its usages are with the schema only, which requires no validation and no `+page.ts`. In that case, just call `defaults` with your adapter and eventual initial data, and you're good to go:
+Fortunately though, a [quick Github search](https://github.com/search?q=superValidateSync%28&type=code) reveals that most of its usages are with the schema only, which requires no validation and no `+page.ts`. In that case, just call `defaults` with your adapter and potential initial data, and you're good to go:
 
 ```ts
 import { defaults } from 'sveltekit-superforms'


### PR DESCRIPTION
A common error for non-native speakers (like myself) is to use "eventual" when we should use "potential".
"Eventual" means "sooner or later" or "ultimate" and can be confusing for English native speakers when the intended meaning is "potential"/"possibly-present".