### PR TITLE
docs: replace type cast with explicit type annotation

### DIFF
--- a/src/routes/concepts/events/+page.md
+++ b/src/routes/concepts/events/+page.md
@@ -180,7 +180,7 @@ let { data } : { data: PageData } = $props();
 
 const { form, errors, message, enhance } = superForm(data.form, {
   onUpdate({ form, result }) {
-    const action = result.data as FormResult<ActionData>;
+    const action: FormResult<ActionData> = result.data;
     // If you've returned from the form action:
     // return { form, extra: 123 }
     if (form.valid && action.extra) {


### PR DESCRIPTION
Replaced `result.data as FormResult<ActionData>` with an explicit declaration (`const action: FormResult<ActionData> = result.data`) to enforce stricter type checking and improve code clarity.

### Why?

1.	Stricter Type Checking:
When you use an explicit type annotation, TypeScript checks that result.data is indeed assignable to FormResult<ActionData>. This helps catch errors where the shape or type of result.data might not match what you expect. In contrast, a type assertion effectively tells the compiler “trust me” and bypasses some of that strict checking.
2.	Clarity and Intent:
The explicit annotation makes your intent clear to anyone reading the code. It says, “I expect result.data to conform to this specific type,” which can aid in code maintainability and clarity.
3.	Safer Refactoring:
With explicit type annotations, if the type of result.data ever changes (or if FormResult<ActionData> is modified), TypeScript will immediately flag the mismatch during compilation. Type assertions may hide such issues because they force the type without verifying that the underlying value matches.

### Example

What if we try and set `"hello"` as a `FormResult<ActionData>`

✅ Declaration complains
![image](https://github.com/user-attachments/assets/ab0fed3b-caa1-42f0-8e1e-ac8da47384da)

⚠️ Casting let's you do potentially dangerous things
![image](https://github.com/user-attachments/assets/ba7d830c-b962-40dc-a0cb-7ca6ed047363)